### PR TITLE
Store provider API keys in Obsidian SecretStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Think of it like a control panel where you can:
 
 **The plugin itself doesn't do any AI processing - it just helps other plugins connect to AI services more easily.**
 
+On supported Obsidian versions, provider API keys are stored in Obsidian SecretStorage instead of the plugin `data.json`. If SecretStorage is unavailable, the plugin falls back to normal settings persistence so existing setups keep working.
+
 <img width="700" alt="image" src="https://github.com/user-attachments/assets/09b6313d-726c-440b-9201-1b2f2e839fa7" />
 
 ## Required by plugins

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,11 +1,29 @@
 export class App {
     workspace: Workspace;
     vault: Vault;
+    secretStorage: SecretStorage;
     appId = 'test-vault-id';
     
     constructor() {
         this.workspace = new Workspace();
         this.vault = new Vault();
+        this.secretStorage = new SecretStorage();
+    }
+}
+
+export class SecretStorage {
+    private secrets = new Map<string, string>();
+
+    async getSecret(key: string): Promise<string | null> {
+        return this.secrets.get(key) ?? null;
+    }
+
+    async setSecret(key: string, value: string): Promise<void> {
+        this.secrets.set(key, value);
+    }
+
+    async deleteSecret(key: string): Promise<void> {
+        this.secrets.delete(key);
     }
 }
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -4,6 +4,7 @@ import AIProvidersPlugin from './main';
 import { DEFAULT_SETTINGS } from './settings';
 import { AIProvidersService } from './AIProvidersService';
 import { logger } from './utils/logger';
+import { IAIProvider } from '@obsidian-ai-providers/sdk';
 
 vi.mock('./AIProvidersService', () => ({
     AIProvidersService: vi.fn().mockImplementation(() => ({
@@ -25,12 +26,29 @@ describe('AIProvidersPlugin', () => {
     let app: any;
     let plugin: AIProvidersPlugin;
 
+    const createProvider = (
+        overrides: Partial<IAIProvider> = {}
+    ): IAIProvider => ({
+        id: 'provider-1',
+        name: 'Provider 1',
+        apiKey: 'secret-key',
+        url: 'https://example.com',
+        type: 'openai',
+        model: 'gpt-4o-mini',
+        ...overrides,
+    });
+
     beforeEach(() => {
         app = {
             workspace: {
                 layoutReady: false,
                 onLayoutReady: vi.fn(cb => cb()),
                 trigger: vi.fn(),
+            },
+            secretStorage: {
+                getSecret: vi.fn().mockResolvedValue(null),
+                setSecret: vi.fn().mockResolvedValue(undefined),
+                deleteSecret: vi.fn().mockResolvedValue(undefined),
             },
         };
 
@@ -50,12 +68,29 @@ describe('AIProvidersPlugin', () => {
     });
 
     it('loads settings and enables logger', async () => {
+        const provider = createProvider();
+        plugin.loadData = vi.fn().mockResolvedValue({
+            debugLogging: true,
+            providers: [provider],
+        });
+
         await plugin.loadSettings();
 
         expect(plugin.settings).toEqual(
             expect.objectContaining({
                 ...DEFAULT_SETTINGS,
                 debugLogging: true,
+                providers: [provider],
+            })
+        );
+        expect(app.secretStorage.setSecret).toHaveBeenCalled();
+        expect(plugin.saveData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providers: [
+                    expect.not.objectContaining({
+                        apiKey: expect.anything(),
+                    }),
+                ],
             })
         );
         expect(logger.setEnabled).toHaveBeenCalledWith(true);
@@ -72,15 +107,102 @@ describe('AIProvidersPlugin', () => {
     });
 
     it('saves settings and re-exposes providers', async () => {
-        plugin.settings = { ...DEFAULT_SETTINGS, providers: [] };
+        plugin.settings = {
+            ...DEFAULT_SETTINGS,
+            providers: [createProvider()],
+        };
         const exposeSpy = vi
             .spyOn(plugin, 'exposeAIProviders')
             .mockImplementation(() => {});
 
         await plugin.saveSettings();
 
-        expect(plugin.saveData).toHaveBeenCalledWith(plugin.settings);
+        expect(app.secretStorage.setSecret).toHaveBeenCalledWith(
+            expect.stringMatching(/^ai-providers-/),
+            'secret-key'
+        );
+        expect(plugin.saveData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providers: [
+                    expect.not.objectContaining({
+                        apiKey: expect.anything(),
+                    }),
+                ],
+            })
+        );
         expect(exposeSpy).toHaveBeenCalled();
+    });
+
+    it('hydrates providers from secret storage when data is already scrubbed', async () => {
+        const provider = createProvider();
+        plugin.loadData = vi.fn().mockResolvedValue({
+            providers: [{ ...provider, apiKey: undefined }],
+        });
+        app.secretStorage.getSecret = vi
+            .fn()
+            .mockResolvedValue(provider.apiKey);
+
+        await plugin.loadSettings();
+
+        expect(plugin.settings.providers?.[0].apiKey).toBe('secret-key');
+        expect(plugin.saveData).not.toHaveBeenCalled();
+    });
+
+    it('keeps plaintext apiKey in persisted data when secret storage is unavailable', async () => {
+        const provider = createProvider();
+        delete app.secretStorage;
+        plugin.settings = {
+            ...DEFAULT_SETTINGS,
+            providers: [provider],
+        };
+
+        await plugin.saveSettings();
+
+        expect(plugin.saveData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providers: [expect.objectContaining({ apiKey: 'secret-key' })],
+            })
+        );
+    });
+
+    it('deletes stored secrets for removed providers', async () => {
+        const keptProvider = createProvider();
+        const removedProvider = createProvider({
+            id: 'provider-2',
+            name: 'Provider 2',
+        });
+        plugin.loadData = vi.fn().mockResolvedValue({
+            providers: [keptProvider, removedProvider],
+        });
+
+        await plugin.loadSettings();
+
+        plugin.settings.providers = [keptProvider];
+        await plugin.saveSettings();
+
+        expect(app.secretStorage.deleteSecret).toHaveBeenCalledWith(
+            expect.stringMatching(/^ai-providers-/)
+        );
+    });
+
+    it('keeps plaintext apiKey when secret storage write fails', async () => {
+        const provider = createProvider();
+        app.secretStorage.setSecret = vi
+            .fn()
+            .mockRejectedValue(new Error('nope'));
+        plugin.settings = {
+            ...DEFAULT_SETTINGS,
+            providers: [provider],
+        };
+
+        await plugin.saveSettings();
+
+        expect(logger.warn).toHaveBeenCalled();
+        expect(plugin.saveData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providers: [expect.objectContaining({ apiKey: 'secret-key' })],
+            })
+        );
     });
 
     it('exposes providers and handles cleanup/reinit errors', async () => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -148,6 +148,22 @@ describe('AIProvidersPlugin', () => {
         expect(plugin.saveData).not.toHaveBeenCalled();
     });
 
+    it('does not hydrate stale secrets over a plaintext fallback apiKey', async () => {
+        const provider = createProvider({ apiKey: 'fallback-key' });
+        plugin.loadData = vi.fn().mockResolvedValue({
+            providers: [provider],
+        });
+        app.secretStorage.getSecret = vi.fn().mockResolvedValue('stale-secret');
+        app.secretStorage.setSecret = vi
+            .fn()
+            .mockRejectedValue(new Error('write failed'));
+
+        await plugin.loadSettings();
+
+        expect(plugin.settings.providers?.[0].apiKey).toBe('fallback-key');
+        expect(app.secretStorage.getSecret).not.toHaveBeenCalled();
+    });
+
     it('keeps plaintext apiKey in persisted data when secret storage is unavailable', async () => {
         const provider = createProvider();
         delete app.secretStorage;
@@ -182,6 +198,35 @@ describe('AIProvidersPlugin', () => {
 
         expect(app.secretStorage.deleteSecret).toHaveBeenCalledWith(
             expect.stringMatching(/^ai-providers-/)
+        );
+    });
+
+    it('deletes stored secrets when a provider apiKey is cleared', async () => {
+        const provider = createProvider();
+        plugin.loadData = vi.fn().mockResolvedValue({
+            providers: [provider],
+        });
+
+        await plugin.loadSettings();
+
+        app.secretStorage.deleteSecret.mockClear();
+        app.secretStorage.setSecret.mockClear();
+        plugin.settings.providers = [{ ...provider, apiKey: '' }];
+
+        await plugin.saveSettings();
+
+        expect(app.secretStorage.setSecret).not.toHaveBeenCalled();
+        expect(app.secretStorage.deleteSecret).toHaveBeenCalledWith(
+            expect.stringMatching(/^ai-providers-/)
+        );
+        expect(plugin.saveData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providers: [
+                    expect.not.objectContaining({
+                        apiKey: expect.anything(),
+                    }),
+                ],
+            })
         );
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -238,6 +238,10 @@ export default class AIProvidersPlugin extends Plugin {
     private async hydrateProviderSecrets(): Promise<void> {
         const providers = await Promise.all(
             this.getProviders().map(async provider => {
+                if (typeof provider.apiKey === 'string') {
+                    return provider;
+                }
+
                 const storedApiKey = await this.readSecret(provider.id);
                 if (storedApiKey === null) {
                     return provider;
@@ -279,6 +283,7 @@ export default class AIProvidersPlugin extends Plugin {
         const providers = await Promise.all(
             this.getProviders().map(async provider => {
                 if (!provider.apiKey) {
+                    await this.deleteSecret(provider.id);
                     return this.omitApiKey(provider);
                 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { Plugin, addIcon } from 'obsidian';
 import type { App } from 'obsidian';
-import { IAIProvidersPluginSettings } from '@obsidian-ai-providers/sdk';
+import {
+    IAIProvider,
+    IAIProvidersPluginSettings,
+} from '@obsidian-ai-providers/sdk';
 import { DEFAULT_SETTINGS, AIProvidersSettingTab } from './settings';
 import { AIProvidersService } from './AIProvidersService';
 import { logger } from './utils/logger';
@@ -29,11 +32,23 @@ import {
 
 type AppWithAIProviders = App & {
     aiProviders?: AIProvidersService;
+    secretStorage?: SecretStorageLike;
 };
+
+type SecretStorageLike = {
+    getSecret(key: string): Promise<string | null>;
+    setSecret(key: string, value: string): Promise<void>;
+    deleteSecret(key: string): Promise<void>;
+};
+
+const SECRET_PREFIX = 'ai-providers-';
+const MAX_SECRET_ID_LENGTH = 64;
+const SECRET_SLUG_LENGTH = 46;
 
 export default class AIProvidersPlugin extends Plugin {
     settings!: IAIProvidersPluginSettings;
     aiProviders!: AIProvidersService;
+    private providerIds = new Set<string>();
 
     async onload() {
         await this.loadSettings();
@@ -86,11 +101,19 @@ export default class AIProvidersPlugin extends Plugin {
             DEFAULT_SETTINGS,
             await this.loadData()
         );
+        await this.migrateProviderSecrets();
+        await this.hydrateProviderSecrets();
+        this.providerIds = this.collectProviderIds();
         logger.setEnabled(this.settings.debugLogging ?? false);
     }
 
     async saveSettings() {
-        await this.saveData(this.settings);
+        const removedProviderIds = this.getRemovedProviderIds();
+        const settingsToPersist = await this.createPersistedSettings();
+
+        await this.saveData(settingsToPersist);
+        await this.deleteSecrets(removedProviderIds);
+        this.providerIds = this.collectProviderIds();
         this.exposeAIProviders();
     }
 
@@ -114,5 +137,165 @@ export default class AIProvidersPlugin extends Plugin {
                 console.error('Error reinitializing embeddings cache:', error);
             });
         }
+    }
+
+    private getSecretStorage(): SecretStorageLike | null {
+        const appWithProviders = this.app as AppWithAIProviders;
+        return appWithProviders.secretStorage ?? null;
+    }
+
+    private collectProviderIds(): Set<string> {
+        return new Set(this.getProviders().map(provider => provider.id));
+    }
+
+    private getRemovedProviderIds(): string[] {
+        const currentIds = this.collectProviderIds();
+
+        return Array.from(this.providerIds).filter(id => !currentIds.has(id));
+    }
+
+    private getProviders(): IAIProvider[] {
+        return this.settings.providers ?? [];
+    }
+
+    private getSecretId(providerId: string): string {
+        const normalizedId =
+            providerId
+                .toLowerCase()
+                .replace(/[^a-z0-9-]+/g, '-')
+                .replace(/^-+|-+$/g, '')
+                .slice(0, SECRET_SLUG_LENGTH) || 'provider';
+
+        const hash = Array.from(providerId)
+            .reduce(
+                (value, character) =>
+                    (value * 31 + character.charCodeAt(0)) >>> 0,
+                0
+            )
+            .toString(36);
+
+        return `${SECRET_PREFIX}${normalizedId}-${hash}`.slice(
+            0,
+            MAX_SECRET_ID_LENGTH
+        );
+    }
+
+    private async readSecret(providerId: string): Promise<string | null> {
+        const secretStorage = this.getSecretStorage();
+        if (!secretStorage) {
+            return null;
+        }
+
+        try {
+            return await secretStorage.getSecret(this.getSecretId(providerId));
+        } catch (error) {
+            logger.warn('Failed to read provider secret', { providerId, error });
+            return null;
+        }
+    }
+
+    private async writeSecret(provider: IAIProvider): Promise<boolean> {
+        const secretStorage = this.getSecretStorage();
+        if (!secretStorage || !provider.apiKey) {
+            return false;
+        }
+
+        try {
+            await secretStorage.setSecret(
+                this.getSecretId(provider.id),
+                provider.apiKey
+            );
+            return true;
+        } catch (error) {
+            logger.warn('Failed to write provider secret', {
+                providerId: provider.id,
+                error,
+            });
+            return false;
+        }
+    }
+
+    private async deleteSecret(providerId: string): Promise<void> {
+        const secretStorage = this.getSecretStorage();
+        if (!secretStorage) {
+            return;
+        }
+
+        try {
+            await secretStorage.deleteSecret(this.getSecretId(providerId));
+        } catch (error) {
+            logger.warn('Failed to delete provider secret', {
+                providerId,
+                error,
+            });
+        }
+    }
+
+    private async deleteSecrets(providerIds: string[]): Promise<void> {
+        await Promise.all(providerIds.map(id => this.deleteSecret(id)));
+    }
+
+    private async hydrateProviderSecrets(): Promise<void> {
+        const providers = await Promise.all(
+            this.getProviders().map(async provider => {
+                const storedApiKey = await this.readSecret(provider.id);
+                if (storedApiKey === null) {
+                    return provider;
+                }
+
+                return {
+                    ...provider,
+                    apiKey: storedApiKey,
+                };
+            })
+        );
+
+        this.settings.providers = providers;
+    }
+
+    private async migrateProviderSecrets(): Promise<void> {
+        const providers = this.getProviders();
+        let didMigrate = false;
+
+        for (const provider of providers) {
+            if (!provider.apiKey) {
+                continue;
+            }
+
+            const didStoreSecret = await this.writeSecret(provider);
+            if (didStoreSecret) {
+                didMigrate = true;
+            }
+        }
+
+        if (!didMigrate) {
+            return;
+        }
+
+        await this.saveData(await this.createPersistedSettings());
+    }
+
+    private async createPersistedSettings(): Promise<IAIProvidersPluginSettings> {
+        const providers = await Promise.all(
+            this.getProviders().map(async provider => {
+                if (!provider.apiKey) {
+                    return this.omitApiKey(provider);
+                }
+
+                const didStoreSecret = await this.writeSecret(provider);
+                return didStoreSecret ? this.omitApiKey(provider) : provider;
+            })
+        );
+
+        return {
+            ...this.settings,
+            providers,
+        };
+    }
+
+    private omitApiKey(provider: IAIProvider): IAIProvider {
+        const persistedProvider = { ...provider };
+        delete persistedProvider.apiKey;
+        return persistedProvider;
     }
 }


### PR DESCRIPTION
## Summary

Store provider `apiKey` values in Obsidian SecretStorage when available instead of persisting them in the plugin `data.json`.

## Changes

- migrate existing plaintext provider API keys into SecretStorage on plugin load
- rehydrate provider objects in memory with `apiKey` values from SecretStorage
- persist provider settings without `apiKey` when SecretStorage writes succeed
- delete stored secrets when a provider is removed
- keep a plaintext fallback when SecretStorage is unavailable or a secret write fails
- add tests covering migration, scrubbed saves, fallback behavior, and secret deletion
- document the new persistence behavior in the README

## Why

Today provider API keys are stored alongside normal plugin settings, which means they can end up in `data.json` in plain text. That creates avoidable exposure risk through sync tools, backups, shared vaults, or Git history.

This change keeps the current runtime provider model intact while moving secrets out of normal settings storage on supported Obsidian versions.

## Compatibility

- On supported Obsidian versions, API keys are stored in SecretStorage.
- If SecretStorage is unavailable, the plugin falls back to normal settings persistence so existing setups continue to work.
- Existing users with plaintext keys are migrated on load when SecretStorage is available.

## Verification

Passed:
- `npm run lint`
- `npm run typecheck`
- `npx vitest run src/main.test.ts src/settings.test.ts --coverage=false`

Repo-wide `npm test` still has unrelated existing failures in:
- `packages/example-plugin/main.test.ts`
- `src/i18n/index.test.ts`
